### PR TITLE
Use TLS (HTTPS) to retrieve composer.phar

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@
 # It may be imported or inherited by other classes.
 #
 class composer::params {
-  $phar_location = 'http://getcomposer.org/composer.phar'
+  $phar_location = 'https://getcomposer.org/composer.phar'
   $target_dir    = '/usr/local/bin'
   $command_name  = 'composer'
   $user          = 'root'

--- a/spec/classes/composer_spec.rb
+++ b/spec/classes/composer_spec.rb
@@ -4,7 +4,7 @@ describe 'composer', :type => :class do
   let(:title) { 'composer' }
 
   it { should contain_wget__fetch('composer-install') \
-    .with_source('http://getcomposer.org/composer.phar') \
+    .with_source('https://getcomposer.org/composer.phar') \
     .with_execuser('root') \
     .with_destination('/usr/local/bin/composer')
   }
@@ -21,7 +21,7 @@ describe 'composer', :type => :class do
     let(:params) {{ :target_dir => '/usr/bin' }}
 
     it { should contain_wget__fetch('composer-install') \
-      .with_source('http://getcomposer.org/composer.phar') \
+      .with_source('https://getcomposer.org/composer.phar') \
       .with_execuser('root') \
       .with_destination('/usr/bin/composer')
     }
@@ -39,7 +39,7 @@ describe 'composer', :type => :class do
     let(:params) {{ :command_name => 'c' }}
 
     it { should contain_wget__fetch('composer-install') \
-      .with_source('http://getcomposer.org/composer.phar') \
+      .with_source('https://getcomposer.org/composer.phar') \
       .with_execuser('root') \
       .with_destination('/usr/local/bin/c')
     }
@@ -57,7 +57,7 @@ describe 'composer', :type => :class do
     let(:params) {{ :auto_update => true }}
 
     it { should contain_wget__fetch('composer-install') \
-      .with_source('http://getcomposer.org/composer.phar') \
+      .with_source('https://getcomposer.org/composer.phar') \
       .with_execuser('root') \
       .with_destination('/usr/local/bin/composer')
     }
@@ -79,7 +79,7 @@ describe 'composer', :type => :class do
     let(:params) {{ :user => 'will' }}
 
     it { should contain_wget__fetch('composer-install') \
-      .with_source('http://getcomposer.org/composer.phar') \
+      .with_source('https://getcomposer.org/composer.phar') \
       .with_execuser('will') \
       .with_destination('/usr/local/bin/composer')
     }


### PR DESCRIPTION
Set the default of the `$phar_location` location to use HTTPS, which provides some guarantee as to the authenticity of the file being downloaded.

HTTPS is supported by getcomposer.org:

```
» curl -I -XHEAD https://getcomposer.org/ 2>/dev/null | head -n 1
» HTTP/1.1 200 OK
```
