### PR TITLE
Update metadata: include OS support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,6 +17,22 @@
       "version_requirement": ">=1.2.0"
     }
   ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "12.04",
+        "14.04"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
   "types": [
 
   ],


### PR DESCRIPTION
Hi William,
I tested the module in:

* Ubuntu 12.04, 14.04
* CentOS 6, 7

The format for `operatingsystem_support` complies with the one used in official Puppet modules, e.g. https://github.com/puppetlabs/puppetlabs-mysql/blob/master/metadata.json.