### PR TITLE
README.md typo s/close/clone/

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ running the following command:
 
     puppet module install willdurand/composer
 
-Otherwise, close this repository and make sure to install the proper
+Otherwise, clone this repository and make sure to install the proper
 dependencies ([`puppet-wget`](https://github.com/maestrodev/puppet-wget)):
 
     git clone git://github.com/willdurand/puppet-composer.git modules/composer


### PR DESCRIPTION
A colleage found this when I blatantly ripped off your repo to make https://github.com/caseyfw/puppet-robo