### PR TITLE
make composer parameters managable via puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ instance. So, please, run the following command:
 Usage
 -----
 
+### Install composer through puppet
+
 Include the `composer` class:
 
     include composer
@@ -63,6 +65,41 @@ It is also possible to specify a custom composer version:
     class { 'composer':
       version => '1.0.0-alpha11',
     }
+
+### Global composer configs
+
+One feature of composer are [global configuration parameters](https://getcomposer.org/doc/06-config.md#config).
+There are some important parameters like ``oauth_token`` for the GitHub API that should be configured through composer.
+
+``` puppet
+::composer::config { 'composer-vagrant-config':
+  ensure  => present,
+  user    => 'vagrant',
+  configs => {
+    'github-oauth' => {
+      'github.com' => 'token'
+    },
+    'process-timeout' => 500,
+    'http-basic' => {
+      'github.com' => ['username', 'password']
+    },
+  },
+}
+```
+
+And removing single params is also possible:
+
+``` puppet
+::composer::config { 'remove-platform':
+  ensure  => absent,
+  configs => ['process-timeout', 'github-oauth.github.com', 'http-basic.github.com'],
+  user    => 'vagrant',
+}
+```
+
+Note that the config items must be structured like when using the CLI. This means that when having a ``gitlab-oauth`` entry for site ``gitlab.org`` then the following key should be removed:
+
+    gitlab-oauth.gitlab.org
 
 Handle dependency order
 -----------------------

--- a/lib/puppet/parser/functions/create_config_hash.rb
+++ b/lib/puppet/parser/functions/create_config_hash.rb
@@ -1,0 +1,47 @@
+def create_hash(value, user, ensure_entry, entry)
+  hash = {
+    :user   => user,
+    :ensure => ensure_entry,
+    :entry  => entry
+  }
+
+  unless value.nil?
+    hash[:value] = value
+  end
+
+  hash
+end
+
+module Puppet::Parser::Functions
+  newfunction(:create_config_hash, :type => :rvalue) do |args|
+    configs      = args[0]
+    user         = args[1].to_s
+    ensure_entry = args[2].to_s
+    hash         = {}
+
+    if configs.is_a? Hash
+      configs.each do |entry, value|
+        if value.is_a? Hash
+          value.each do |key, value|
+            value  = value.join ' ' if value.is_a? Array
+            entry  = "'#{entry}'.'#{key}'"
+
+            hash["#{entry}-#{user}-create"] = create_hash value, user, ensure_entry, entry
+          end
+        else
+          if value.is_a? Array
+            value = value.join ' '
+          end
+
+          hash["#{entry}-#{user}-create"] = create_hash value, user, ensure_entry, entry
+        end
+      end
+    else
+      configs.each do |value|
+        hash["#{value}-#{user}-remove"] = create_hash nil, user, 'absent', value
+      end
+    end
+
+    return hash
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,37 @@
+# = Define: composer::config
+#
+# == Parameters:
+#
+# [*ensure*]
+#   Whether to install or remove the parameters.
+#
+# [*user*]
+#   User which should own the configuration.
+#
+# [*configs*]
+#   Hash that contains the config values.
+#
+# == Example:
+#
+#   ::composer::config { 'composer-vagrant':
+#     ensure  => present,
+#     user    => 'vagrant',
+#     configs => {
+#       'github-oauth' => {
+#         'github.com' => 'token',
+#       },
+#     },
+#   }
+#
+define composer::config(
+  $ensure  = present,
+  $user    = undef,
+  $configs = {}
+) {
+  $composer_user = $user ? {
+    undef   => $::composer::params::user,
+    default => $user
+  }
+
+  create_resources('composer::config::entry', create_config_hash($configs, $composer_user, $ensure))
+}

--- a/manifests/config/entry.pp
+++ b/manifests/config/entry.pp
@@ -1,0 +1,35 @@
+# = Define: composer::config::entry
+#
+# == Parameters:
+#
+# [*ensure*]
+#   Whether to apply or remove the config entry.
+#
+# [*entry*]
+#   Parameter name.
+#
+# [*value*]
+#   Configuration value.
+#
+# [*user*]
+#   User which should own the configs.
+#
+define composer::config::entry($entry, $user, $ensure, $value = undef) {
+  if $caller_module_name != $module_name {
+    warning('::composer::config::entry is not meant for public use!')
+  }
+
+  $home_dir     = "/home/${user}"
+  $cmd_template = "${::composer::composer_command_name} config -g"
+  $cmd          = $ensure ? {
+    present => "${cmd_template} ${entry} ${value}",
+    default => "${cmd_template} --unset ${entry}"
+  }
+
+  exec { "composer-config-entry-${entry}-${user}-${ensure}":
+    command     => $cmd,
+    user        => $user,
+    require     => Class['::composer'],
+    environment => "HOME=${home_dir}",
+  }
+}

--- a/spec/defines/composer_config_entry_spec.rb
+++ b/spec/defines/composer_config_entry_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'composer::config::entry', :type => :define do
+  let(:title) { 'composer::config::entry' }
+  let(:pre_condition) { 'class { "::composer": }' }
+
+  describe 'it installs the parameters properly' do
+    let(:params) {{
+      :entry  => '\'process-timeout\'',
+      :value  => 500,
+      :ensure => 'present',
+      :user   => 'vagrant'
+    }}
+
+    it { should contain_exec('composer-config-entry-\'process-timeout\'-vagrant-present') \
+      .with_command('composer config -g \'process-timeout\' 500') \
+      .with_user('vagrant') \
+      .with_environment('HOME=/home/vagrant')
+    }
+  end
+
+  describe 'it removes parameters' do
+    let(:params) {{
+      :entry  => '\'process-timeout\'',
+      :value  => nil,
+      :ensure => 'absent',
+      :user   => 'vagrant'
+    }}
+
+    it { should contain_exec('composer-config-entry-\'process-timeout\'-vagrant-absent') \
+      .with_command('composer config -g --unset \'process-timeout\'') \
+      .with_user('vagrant') \
+      .with_environment('HOME=/home/vagrant')
+    }
+  end
+end

--- a/spec/defines/composer_config_spec.rb
+++ b/spec/defines/composer_config_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe 'composer::config', :type => :define do
+  let(:title) { 'composer::config' }
+  let(:pre_condition) { 'class { "::composer": }' }
+
+  describe 'it installs the parameters properly' do
+    let(:params) {{
+      :ensure  => 'present',
+      :user    => 'vagrant',
+      :configs => {
+        'github-oauth' => {
+          'github.com' => 'token'
+        },
+        'http-basic' => {
+          'github.com' => ['username', 'password']
+        },
+      },
+    }}
+
+    it { should contain_exec('composer-config-entry-\'github-oauth\'.\'github.com\'-vagrant-present') \
+      .with_command('composer config -g \'github-oauth\'.\'github.com\' token') \
+      .with_user('vagrant') \
+      .with_environment('HOME=/home/vagrant')
+    }
+
+    it { should contain_exec('composer-config-entry-\'http-basic\'.\'github.com\'-vagrant-present') \
+      .with_command('composer config -g \'http-basic\'.\'github.com\' username password') \
+      .with_user('vagrant') \
+      .with_environment('HOME=/home/vagrant')
+    }
+  end
+
+  describe 'it removes parameters properly' do
+    let(:params) {{
+      :ensure  => 'absent',
+      :user    => 'vagrant',
+      :configs => ['github-oauth.github.com', 'process-timeout']
+    }}
+
+    it { should contain_exec('composer-config-entry-github-oauth.github.com-vagrant-absent') \
+      .with_command('composer config -g --unset github-oauth.github.com')
+      .with_user('vagrant')
+      .with_environment('HOME=/home/vagrant')
+    }
+
+    it { should contain_exec('composer-config-entry-process-timeout-vagrant-absent') \
+      .with_command('composer config -g --unset process-timeout')
+      .with_user('vagrant')
+      .with_environment('HOME=/home/vagrant')
+    }
+  end
+end

--- a/spec/functions/create_config_hash_spec.rb
+++ b/spec/functions/create_config_hash_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe 'create_config_hash' do
+  before(:each) do
+    Puppet::Parser::Functions.function(:node_default_instance_directory)
+  end
+
+  describe 'build hashes for config generation' do
+    it do
+      should run.with_params({
+        "github-oauth" => {
+          'github.com' => 'token'
+        },
+        "process-timeout" => 500,
+        "github-protocols" => ['ssh', 'https']
+      }, :vagrant, :present).and_return({
+        "'github-oauth'.'github.com'-vagrant-create" => {
+          :value  => "token",
+          :user   => "vagrant",
+          :ensure => 'present',
+          :entry  => "'github-oauth'.'github.com'"
+        },
+        "process-timeout-vagrant-create" => {
+          :value  => 500,
+          :user   => "vagrant",
+          :ensure => 'present',
+          :entry  => "process-timeout"
+        },
+        "github-protocols-vagrant-create" => {
+          :value  => "ssh https",
+          :user   => "vagrant",
+          :ensure => 'present',
+          :entry  => "github-protocols"
+        }
+      })
+    end
+  end
+
+  describe 'removes parameters' do
+    it do
+      should run.with_params(['github-oauth.github.com', 'process-timeout'], :vagrant, :absent).and_return({
+        "github-oauth.github.com-vagrant-remove" => {
+          :user   => "vagrant",
+          :ensure => 'absent',
+          :entry  => "github-oauth.github.com"
+        },
+        "process-timeout-vagrant-remove" => {
+          :user   => "vagrant",
+          :ensure => 'absent',
+          :entry  => "process-timeout"
+        }
+      })
+    end
+  end
+end


### PR DESCRIPTION
### Overview

Composer has a heavy configuration manager which contains a lot of configuration parameters that can be passed to composer. The aim of this feature is a generic approach to deal with those parameters without ending up in managing tons of parameters through puppet resources.

### Related issues

resolves #2 

