### PR TITLE
exec chmod is bad juju

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,12 +64,10 @@ class composer (
     execuser    => $composer_user,
   }
 
-  exec { 'composer-fix-permissions':
-    command => "chmod a+x ${composer_command_name}",
-    path    => '/usr/bin:/bin:/usr/sbin:/sbin',
-    cwd     => $composer_target_dir,
-    user    => $composer_user,
-    unless  => "test -x ${composer_target_dir}/${composer_command_name}",
+  file { "${composer_target_dir}/${composer_command_name}":
+    ensure  => file,
+    owner   => $composer_user,
+    mode    => '0755',
     require => Wget::Fetch['composer-install'],
   }
 
@@ -79,7 +77,7 @@ class composer (
       environment => [ "COMPOSER_HOME=${composer_target_dir}" ],
       path        => "/usr/bin:/bin:/usr/sbin:/sbin:${composer_target_dir}",
       user        => $composer_user,
-      require     => Exec['composer-fix-permissions'],
+      require     => File["${composer_target_dir}/${composer_command_name}"],
     }
   }
 }

--- a/spec/classes/composer_spec.rb
+++ b/spec/classes/composer_spec.rb
@@ -9,11 +9,10 @@ describe 'composer', :type => :class do
     .with_destination('/usr/local/bin/composer')
   }
 
-  it { should contain_exec('composer-fix-permissions') \
-    .with_command('chmod a+x composer') \
-    .with_user('root') \
-    .with_cwd('/usr/local/bin')
-  }
+    it { should contain_file('/usr/local/bin/composer') \
+      .with_owner('root') \
+      .with_mode('0755')
+    }
 
   it { should_not contain_exec('composer-update') }
 
@@ -26,10 +25,9 @@ describe 'composer', :type => :class do
       .with_destination('/usr/bin/composer')
     }
 
-    it { should contain_exec('composer-fix-permissions') \
-      .with_command('chmod a+x composer') \
-      .with_user('root') \
-      .with_cwd('/usr/bin')
+    it { should contain_file('/usr/bin/composer') \
+      .with_owner('root') \
+      .with_mode('0755')
     }
 
     it { should_not contain_exec('composer-update') }
@@ -44,10 +42,9 @@ describe 'composer', :type => :class do
       .with_destination('/usr/local/bin/c')
     }
 
-    it { should contain_exec('composer-fix-permissions') \
-      .with_command('chmod a+x c') \
-      .with_user('root') \
-      .with_cwd('/usr/local/bin')
+    it { should contain_file('/usr/local/bin/c') \
+      .with_owner('root') \
+      .with_mode('0755')
     }
 
     it { should_not contain_exec('composer-update') }
@@ -62,10 +59,9 @@ describe 'composer', :type => :class do
       .with_destination('/usr/local/bin/composer')
     }
 
-    it { should contain_exec('composer-fix-permissions') \
-      .with_command('chmod a+x composer') \
-      .with_user('root') \
-      .with_cwd('/usr/local/bin')
+    it { should contain_file('/usr/local/bin/composer') \
+      .with_owner('root') \
+      .with_mode('0755')
     }
 
     it { should contain_exec('composer-update') \
@@ -84,10 +80,9 @@ describe 'composer', :type => :class do
       .with_destination('/usr/local/bin/composer')
     }
 
-    it { should contain_exec('composer-fix-permissions') \
-      .with_command('chmod a+x composer') \
-      .with_user('will') \
-      .with_cwd('/usr/local/bin')
+    it { should contain_file('/usr/local/bin/composer') \
+      .with_owner('will') \
+      .with_mode('0755')
     }
 
     it { should_not contain_exec('composer-update') }


### PR DESCRIPTION
Just let Puppet do its job. That's what it's designed for. The file resource doesn't specify content, only owner and mode. So that's all that Puppet will correct when it's evaluated.

This is untested, so you may have to tweak it slightly, but this practice is much better than chaining a chmod exec like you're writing a shell script.