### PR TITLE
make group of composer executable configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ executable:
       user => 'foo',
     }
 
+As the user is configurable, the group is changeable, too:
+
+    class { 'composer':
+      group => 'owner_group_name',
+    }
+
 It is also possible to specify a custom composer version:
 
     class { 'composer':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,10 @@
 #   Whether to run `composer self-update`.
 #
 # [*version*]
-#   Custom composer version
+#   Custom composer version.
+#
+# [*group*]
+#   Owner group of the composer executable.
 #
 # == Example:
 #
@@ -33,7 +36,8 @@ class composer (
   $command_name = 'UNDEF',
   $user         = 'UNDEF',
   $auto_update  = false,
-  $version      = undef
+  $version      = undef,
+  $group        = undef,
 ) {
 
   include composer::params
@@ -68,6 +72,7 @@ class composer (
     ensure  => file,
     owner   => $composer_user,
     mode    => '0755',
+    group   => $group,
     require => Wget::Fetch['composer-install'],
   }
 

--- a/spec/classes/composer_spec.rb
+++ b/spec/classes/composer_spec.rb
@@ -97,4 +97,14 @@ describe 'composer', :type => :class do
         .with_destination('/usr/local/bin/composer')
     }
   end
+
+  describe 'with a given group' do
+    let(:params) {{ :group => 'puppet' }}
+
+    it { should contain_file('/usr/local/bin/composer') \
+      .with_owner('root') \
+      .with_group('puppet') \
+      .with_mode('0755') \
+    }
+  end
 end


### PR DESCRIPTION
### Overview

make group parameter configurable.
After the changes in #20 it is now possible to configure the executable easily.

### Related issues

resolves #4 

