### PR TITLE
remove unnecessary cwd parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,6 @@ class composer (
   validate_bool($auto_update)
   validate_string($version)
   validate_string($group)
-  validate_string($download_timeout)
 
   ensure_packages(['wget'])
   include composer::params
@@ -77,7 +76,6 @@ class composer (
   $composer_full_path = "${composer_target_dir}/${composer_command_name}"
   exec { 'composer-install':
     command => "/usr/bin/wget -O ${composer_full_path} ${target}",
-    cwd     => $target_dir,
     user    => $composer_user,
     unless  => "test -s '${composer_full_path}'",
     timeout => $download_timeout,


### PR DESCRIPTION
### Overview

In the previous PR the path usage has been refactored. A early prototype of the composer downloader required this, but it has been removed now as it is unnecessary and causes bugs

### Related issues

resolves #29