### PR TITLE
check whether the configuration parameter is already applied be…

### DIFF
--- a/manifests/config/entry.pp
+++ b/manifests/config/entry.pp
@@ -38,10 +38,19 @@ define composer::config::entry($entry, $user, $ensure, $value = undef, $custom_h
     default => "${cmd_template} --unset ${entry}"
   }
 
+  $unless = $ensure ? {
+    present => "/usr/bin/test `${cmd_template} ${entry}` = ${value}",
+
+    # NOTE: in this case the parameter will be resetted to the default value so it cannot be checked properly
+    # when to execute the command to remove the command or not.
+    default => undef,
+  }
+
   exec { "composer-config-entry-${entry}-${user}-${ensure}":
     command     => $cmd,
     user        => $user,
     require     => Class['::composer'],
     environment => "HOME=${home_dir}",
+    unless      => $unless
   }
 }

--- a/spec/defines/composer_config_entry_spec.rb
+++ b/spec/defines/composer_config_entry_spec.rb
@@ -15,7 +15,8 @@ describe 'composer::config::entry', :type => :define do
     it { should contain_exec('composer-config-entry-\'process-timeout\'-vagrant-present') \
       .with_command('/usr/local/bin/composer config -g \'process-timeout\' 500') \
       .with_user('vagrant') \
-      .with_environment('HOME=/home/vagrant')
+      .with_environment('HOME=/home/vagrant') \
+      .with_unless('/usr/bin/test `/usr/local/bin/composer config -g \'process-timeout\'` = 500') \
     }
   end
 


### PR DESCRIPTION
### Overview

In order to avoid duplicated executions, a ``unless`` check will be executed before applying puppet parameters.

__Note:__ it isn't possible to create unless checks for removing parameters:
The thing is that in case of removing a parameter, it will be resetted to the default value. Therefore it cannot be checked properly whether the parameter should be removed or not and removals will be executed in every puppet run.

### Related issues

resolves #27