### PR TITLE
Require Package['wget'] before running install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,7 @@ class composer (
     user    => $composer_user,
     creates => $composer_full_path,
     timeout => $download_timeout,
+    require => Package['wget'],
   }
 
   file { "${composer_target_dir}/${composer_command_name}":


### PR DESCRIPTION
The wget package needs to be installed before Exec['composer-install'] runs. Make this dependency explicit with a 'require' parameter on the 'composer-install' resource.