### PR TITLE
Tests won't run without 'json' gem installed, add to .gemfile

### DIFF
--- a/.gemfile
+++ b/.gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 puppetVersion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'] : '~> 2.7.0'
 
 gem 'rake'
+gem 'json'
 gem 'puppet', puppetVersion
 gem 'puppet-lint'
 gem 'puppet-syntax'


### PR DESCRIPTION
### Overview

Running tests fails without the 'json' gem:

```
BUNDLE_GEMFILE=.gemfile bundle exec rake spec
...
rake aborted!
LoadError: cannot load such file -- json
```

This PR adds 'json' to the .gemfile