### PR TITLE
#41 - use 'ensure > installed' in ensure_packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,9 @@ class composer (
   validate_string($version)
   validate_string($group)
 
-  ensure_packages(['wget'])
+  ensure_packages(['wget'], {
+    ensure => installed,
+  })
   include composer::params
 
   $composer_target_dir = $target_dir ? {


### PR DESCRIPTION
### Overview

Avoid a "duplicate package (wget)" error when using Puppet modules which are declaring a wget ressource by using ensure_* functions and passing it 'ensure' parameter set to 'installed' (standard way of declaring ressource with ensure_* functions).

### Related issues

[Duplicate declaration (wget) with willdurand/nodejs](https://github.com/willdurand/puppet-composer/issues/41)
