### PR TITLE
make version usefull for reinstalling

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,10 +79,16 @@ class composer (
   }
 
   $composer_full_path = "${composer_target_dir}/${composer_command_name}"
+
+  $unless = $version ? {
+    undef   => "/usr/bin/test -f ${composer_full_path}",
+    default => "${composer_full_path} -V |grep -q $version"
+  }
+
   exec { 'composer-install':
     command => "/usr/bin/wget --no-check-certificate -O ${composer_full_path} ${target}",
     user    => $composer_user,
-    creates => $composer_full_path,
+    unless  => $unless,
     timeout => $download_timeout,
     require => Package['wget'],
   }

--- a/spec/classes/composer_spec.rb
+++ b/spec/classes/composer_spec.rb
@@ -6,7 +6,7 @@ describe 'composer', :type => :class do
   it { should contain_exec('composer-install') \
     .with_command('/usr/bin/wget --no-check-certificate -O /usr/local/bin/composer https://getcomposer.org/composer.phar') \
     .with_user('root') \
-    .with_creates('/usr/local/bin/composer')
+    .with_unless('/usr/bin/test -f /usr/local/bin/composer')
   }
 
   it { should contain_file('/usr/local/bin/composer') \
@@ -15,7 +15,6 @@ describe 'composer', :type => :class do
   }
 
   it { should_not contain_exec('composer-update') }
-
   describe 'with a given target_dir' do
     let(:params) {{ :target_dir => '/usr/bin' }}
 
@@ -89,6 +88,7 @@ describe 'composer', :type => :class do
     it { should contain_exec('composer-install') \
       .with_command('/usr/bin/wget --no-check-certificate -O /usr/local/bin/composer https://getcomposer.org/download/1.0.0-alpha11/composer.phar') \
       .with_user('root') \
+      .with_unless('/usr/local/bin/composer -V |grep -q 1.0.0-alpha11')
     }
   end
 


### PR DESCRIPTION
### Overview

Right now the version parameter does only work at the first install. After that the "creates" param of exec disables any update/downgrade. I added a unless with test and grep to install the correct version.

We could use the self-update of composer to update to a specific version, but i dont know how that works for downgrades and it could possibly make you packages unable to work.

