### PR TITLE
Improve unless statement to fail when composer doesn't exist yet

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,7 +82,7 @@ class composer (
 
   $unless = $version ? {
     undef   => "/usr/bin/test -f ${composer_full_path}",
-    default => "${composer_full_path} -V |grep -q ${version}"
+    default => "/usr/bin/test -f ${composer_full_path} && ${composer_full_path} -V |grep -q ${version}"
   }
 
   exec { 'composer-install':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,11 +86,12 @@ class composer (
   }
 
   exec { 'composer-install':
-    command => "/usr/bin/wget --no-check-certificate -O ${composer_full_path} ${target}",
-    user    => $composer_user,
-    unless  => $unless,
-    timeout => $download_timeout,
-    require => Package['wget'],
+    command     => "/usr/bin/wget --no-check-certificate -O ${composer_full_path} ${target}",
+    environment => [ "COMPOSER_HOME=${composer_target_dir}" ],
+    user        => $composer_user,
+    unless      => $unless,
+    timeout     => $download_timeout,
+    require     => Package['wget'],
   }
 
   file { "${composer_target_dir}/${composer_command_name}":

--- a/spec/classes/composer_spec.rb
+++ b/spec/classes/composer_spec.rb
@@ -88,7 +88,7 @@ describe 'composer', :type => :class do
     it { should contain_exec('composer-install') \
       .with_command('/usr/bin/wget --no-check-certificate -O /usr/local/bin/composer https://getcomposer.org/download/1.0.0-alpha11/composer.phar') \
       .with_user('root') \
-      .with_unless('/usr/local/bin/composer -V |grep -q 1.0.0-alpha11')
+      .with_unless('/usr/bin/test -f /usr/local/bin/composer && /usr/local/bin/composer -V |grep -q 1.0.0-alpha11')
     }
   end
 


### PR DESCRIPTION
### Overview
This should fix the case when someone is installing composer for the first time, but they specify a value for the `version` param.

When I initially tried using the module (version 1.2.5), I would encounter this:

```
Debug: Resource package[wget] was not determined to be defined
Debug: Create new resource package[wget] with params {"ensure"=>"present"}
Debug: importing '/etc/puppetlabs/code/modules/composer/manifests/params.pp' in environment production
Debug: Automatically imported composer::params from composer/params into production
Debug: Evicting cache entry for environment 'production'
Debug: Caching environment 'production' (ttl = 0 sec)
Notice: Compiled catalog for ubuntu-server-1604-x64-01 in environment production in 0.22 seconds
Debug: /Package[wget]: Provider apt does not support features virtual_packages; not managing attribute allow_virtual
Debug: Creating default schedules
Debug: Loaded state in 0.02 seconds
Debug: Loaded state in 0.02 seconds
Debug: Loaded transaction store file in 0.00 seconds
Info: Applying configuration version '1486582520'
Debug: /Stage[main]/Composer/Exec[composer-install]/require: subscribes to Package[wget]
Debug: /Stage[main]/Composer/File[/usr/local/bin/composer]/require: subscribes to Exec[composer-install]
Debug: /Stage[main]/Composer/Exec[composer-install]: Skipping automatic relationship with File[/usr/local/bin/composer]
Debug: Prefetching apt resources for package
Debug: Executing '/usr/bin/dpkg-query -W --showformat '${Status} ${Package} ${Version}\n''
Error: /Stage[main]/Composer/Exec[composer-install]: Could not evaluate: Could not find command '/usr/local/bin/composer'
Notice: /Stage[main]/Composer/File[/usr/local/bin/composer]: Dependency Exec[composer-install] has failures: true
Warning: /Stage[main]/Composer/File[/usr/local/bin/composer]: Skipping because of failed dependencies
Debug: /Stage[main]/Composer/File[/usr/local/bin/composer]: Resource is being skipped, unscheduling all events
Debug: Class[Composer]: Resource is being skipped, unscheduling all events
Debug: Stage[main]: Resource is being skipped, unscheduling all events
Debug: Finishing transaction 31637440
Debug: Storing state
Debug: Stored state in 0.02 seconds
Notice: Applied catalog in 0.06 seconds
Debug: Applying settings catalog for sections reporting, metrics
Debug: Finishing transaction 33495900
Debug: Received report to process from ubuntu-server-1604-x64-01
Debug: Evicting cache entry for environment 'production'
Debug: Caching environment 'production' (ttl = 0 sec)
Debug: Processing report from ubuntu-server-1604-x64-01 with processor Puppet::Reports::Store
```

The critical part is this:  `Could not evaluate: Could not find command '/usr/local/bin/composer'`
- Which led me to closely examine the exec resource
- I found that it relies on a dynamically set `unless` param
  - In the case when the `version` param is set, it assumes that `/usr/local/bin/composer` exists
    - This is the crux of the problem.  On fresh installs, it won't exist

So, the fix is to change the unless statement to short circuit when the binary doesn't even exist yet.

### Related issues
- May be related to #46