### PR TITLE
Make compatible with FreeBSD

### DIFF
--- a/manifests/config/entry.pp
+++ b/manifests/config/entry.pp
@@ -41,7 +41,7 @@ define composer::config::entry(
   }
 
   $unless = $ensure ? {
-    present => "/usr/bin/test `${cmd_template} ${entry}` = ${value}",
+    present => "test `${cmd_template} ${entry}` = ${value}",
 
     # NOTE: in this case the parameter will be resetted to the default value so it cannot be checked properly
     # when to execute the command to remove the command or not.
@@ -50,6 +50,7 @@ define composer::config::entry(
 
   exec { "composer-config-entry-${entry}-${user}-${ensure}":
     command     => $cmd,
+    path        => '/usr/bin:/bin:/usr/local/bin:/usr/sbin:/sbin:/usr/local/sbin',
     user        => $user,
     require     => Class['::composer'],
     environment => "HOME=${home_dir}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,12 +59,13 @@ class composer (
   $composer_full_path = "${target_dir}/${command_name}"
 
   $unless = $version ? {
-    undef   => "/usr/bin/test -f ${composer_full_path}",
-    default => "/usr/bin/test -f ${composer_full_path} && ${composer_full_path} -V |grep -q ${version}"
+    undef   => "test -f ${composer_full_path}",
+    default => "test -f ${composer_full_path} && ${composer_full_path} -V |grep -q ${version}"
   }
 
   exec { 'composer-install':
-    command     => "/usr/bin/wget --no-check-certificate -O ${composer_full_path} ${target}",
+    command     => "wget --no-check-certificate -O ${composer_full_path} ${target}",
+    path        => '/usr/bin:/bin:/usr/local/bin:/usr/sbin:/sbin:/usr/local/sbin',
     environment => [ "COMPOSER_HOME=${target_dir}" ],
     user        => $user,
     unless      => $unless,

--- a/metadata.json
+++ b/metadata.json
@@ -34,6 +34,9 @@
         "8",
         "9"
       ]
+    },
+    {
+      "operatingsystem": "FreeBSD"
     }
   ],
   "requirements": [

--- a/spec/classes/composer_spec.rb
+++ b/spec/classes/composer_spec.rb
@@ -4,9 +4,9 @@ describe 'composer', :type => :class do
   let(:title) { '::composer' }
 
   it { should contain_exec('composer-install') \
-    .with_command('/usr/bin/wget --no-check-certificate -O /usr/local/bin/composer https://getcomposer.org/composer-stable.phar') \
+    .with_command('wget --no-check-certificate -O /usr/local/bin/composer https://getcomposer.org/composer-stable.phar') \
     .with_user('root') \
-    .with_unless('/usr/bin/test -f /usr/local/bin/composer')
+    .with_unless('test -f /usr/local/bin/composer')
   }
 
   it { should contain_file('/usr/local/bin/composer') \
@@ -19,7 +19,7 @@ describe 'composer', :type => :class do
     let(:params) {{ :target_dir => '/usr/bin' }}
 
     it { should contain_exec('composer-install') \
-      .with_command('/usr/bin/wget --no-check-certificate -O /usr/bin/composer https://getcomposer.org/composer-stable.phar') \
+      .with_command('wget --no-check-certificate -O /usr/bin/composer https://getcomposer.org/composer-stable.phar') \
       .with_user('root') \
     }
 
@@ -35,7 +35,7 @@ describe 'composer', :type => :class do
     let(:params) {{ :command_name => 'c' }}
 
     it { should contain_exec('composer-install') \
-      .with_command('/usr/bin/wget --no-check-certificate -O /usr/local/bin/c https://getcomposer.org/composer-stable.phar') \
+      .with_command('wget --no-check-certificate -O /usr/local/bin/c https://getcomposer.org/composer-stable.phar') \
       .with_user('root') \
     }
 
@@ -51,7 +51,7 @@ describe 'composer', :type => :class do
     let(:params) {{ :auto_update => true }}
 
     it { should contain_exec('composer-install') \
-      .with_command('/usr/bin/wget --no-check-certificate -O /usr/local/bin/composer https://getcomposer.org/composer-stable.phar') \
+      .with_command('wget --no-check-certificate -O /usr/local/bin/composer https://getcomposer.org/composer-stable.phar') \
       .with_user('root') \
     }
 
@@ -70,7 +70,7 @@ describe 'composer', :type => :class do
     let(:params) {{ :user => 'will' }}
 
     it { should contain_exec('composer-install') \
-      .with_command('/usr/bin/wget --no-check-certificate -O /usr/local/bin/composer https://getcomposer.org/composer-stable.phar') \
+      .with_command('wget --no-check-certificate -O /usr/local/bin/composer https://getcomposer.org/composer-stable.phar') \
       .with_user('will') \
     }
 
@@ -86,9 +86,9 @@ describe 'composer', :type => :class do
     let(:params) {{ :version => '1.0.0-alpha11' }}
 
     it { should contain_exec('composer-install') \
-      .with_command('/usr/bin/wget --no-check-certificate -O /usr/local/bin/composer https://getcomposer.org/download/1.0.0-alpha11/composer.phar') \
+      .with_command('wget --no-check-certificate -O /usr/local/bin/composer https://getcomposer.org/download/1.0.0-alpha11/composer.phar') \
       .with_user('root') \
-      .with_unless('/usr/bin/test -f /usr/local/bin/composer && /usr/local/bin/composer -V |grep -q 1.0.0-alpha11')
+      .with_unless('test -f /usr/local/bin/composer && /usr/local/bin/composer -V |grep -q 1.0.0-alpha11')
     }
   end
 
@@ -106,7 +106,7 @@ describe 'composer', :type => :class do
     let(:params) {{ :download_timeout => '25' }}
 
     it { should contain_exec('composer-install') \
-      .with_command('/usr/bin/wget --no-check-certificate -O /usr/local/bin/composer https://getcomposer.org/composer-stable.phar') \
+      .with_command('wget --no-check-certificate -O /usr/local/bin/composer https://getcomposer.org/composer-stable.phar') \
       .with_timeout('25') \
     }
   end

--- a/spec/defines/composer_config_entry_spec.rb
+++ b/spec/defines/composer_config_entry_spec.rb
@@ -16,7 +16,7 @@ describe 'composer::config::entry', :type => :define do
       .with_command('/usr/local/bin/composer config -g \'process-timeout\' 500') \
       .with_user('vagrant') \
       .with_environment('HOME=/home/vagrant') \
-      .with_unless('/usr/bin/test `/usr/local/bin/composer config -g \'process-timeout\'` = 500') \
+      .with_unless('test `/usr/local/bin/composer config -g \'process-timeout\'` = 500') \
     }
   end
 


### PR DESCRIPTION
### Overview

On FreeBSD several commands are installed in different paths when compared to Linux. This can easily be mitigated by relying on properly configured search paths instead of full paths.