### PR TITLE
Prevent sudo session clearing on installation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,7 +66,7 @@ class composer (
   exec { 'composer-install':
     command     => "wget --no-check-certificate -O ${composer_full_path} ${target}",
     path        => '/usr/bin:/bin:/usr/local/bin:/usr/sbin:/sbin:/usr/local/sbin',
-    environment => [ "COMPOSER_HOME=${target_dir}" ],
+    environment => [ "COMPOSER_HOME=${target_dir}", "COMPOSER_ALLOW_SUPERUSER=1" ],
     user        => $user,
     unless      => $unless,
     timeout     => $download_timeout,


### PR DESCRIPTION
When you have the Composer module included and run:
```shell
$ sudo puppet agent -t
```
it will clear the sudo session cache. This is a Composer security measure described [here](https://getcomposer.org/root).

This PR will prevent clearing this cache when you _install_ Composer, so subsequent runs of `sudo puppet agent -t` won't need your password again and again. It is safe because installing Composer only runs `composer -V` to get the current Composer version.

