### PR TITLE
fix: Use HTTPS instead of GIT protocol for cloning

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,5 @@ fixtures:
   symlinks:
     composer: "#{source_dir}"
   repositories:
-    stdlib: git://github.com/puppetlabs/puppetlabs-stdlib.git
-    cron_core: git://github.com/puppetlabs/puppetlabs-cron_core.git
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
+    cron_core: https://github.com/puppetlabs/puppetlabs-cron_core.git

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ running the following command:
 Otherwise, clone this repository and make sure to install the proper
 dependencies ([`puppetlabs-stdlib`](https://github.com/puppetlabs/puppetlabs-stdlib), [`puppetlabs-cron_core`](https://github.com/puppetlabs/puppetlabs-cron_core)):
 
-    git clone git://github.com/willdurand/puppet-composer.git modules/composer
+    git clone https://github.com/willdurand/puppet-composer.git modules/composer
 
 ### ``puppet-wget`` module
 


### PR DESCRIPTION
### Overview

Since 2022-01-11, GitHub has deprecated the usage of the git:// protocol
in favour of the more secure https:// — cf.
https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

This causes the following error when, e.g., cloning this repo as
submodule:

> The unauthenticated git protocol on port 9418 is no longer supported.
> Please see
> https://github.blog/2021-09-01-improving-git-protocol-security-github/
> for more information.

As suggested in https://stackoverflow.com/a/70663683/5433628 we have
then replaced URLs using git:// by their https:// equivalent.

### Related issues

n/a
